### PR TITLE
feat: Implement 'Impossible Mode' where player cannot win at score 3

### DIFF
--- a/nice.js
+++ b/nice.js
@@ -112,6 +112,20 @@ const rpsGame = () => {
   };
 
   const compareHand = (pChoice, compChoice) => {
+    // Rigging logic: If player's score is 3, computer always wins this round.
+    if (playerScore === 3) {
+      if (pChoice === "rock") {
+        compChoice = "paper"; // Paper beats rock
+      } else if (pChoice === "paper") {
+        compChoice = "scissors"; // Scissors beats paper
+      } else if (pChoice === "scissors") {
+        compChoice = "rock"; // Rock beats scissors
+      }
+      // Note: The computer's displayed hand image in playMatch's setTimeout
+      // will still show the original random compChoice, but the game logic here
+      // will use the overridden compChoice, ensuring a computer win.
+    }
+
     if (pChoice === compChoice) {
       handleRoundResult(false, true);
       return;


### PR DESCRIPTION
This commit introduces a new game mechanic where if your score reaches 3, you are prevented from winning the next round. The game logic ensures the computer will win that critical round.

Key changes:

-   Modified the `compareHand(pChoice, compChoice)` function in `nice.js`.
-   If `playerScore` is 3 when `compareHand` is called, the `compChoice` is programmatically altered to be the choice that defeats your `pChoice`.
-   This ensures the computer wins the round if your score is 3, effectively making it impossible for you to achieve the winning score of 4 if you reach 3 points.
-   The computer's displayed hand image will still show its original, randomly selected choice for a more 'subtle' implementation of this rule.